### PR TITLE
Add hubert MTL

### DIFF
--- a/examples/hubert/config/pretrain/hubert_base_librispeech_mtl.yaml
+++ b/examples/hubert/config/pretrain/hubert_base_librispeech_mtl.yaml
@@ -26,7 +26,7 @@ task:
   data: ???
   ssl_data: ??? # Added by me for MTL config
   label_dir: ???
-  labels: ???
+  labels: ["km"]
   label_rate: ${model.label_rate}
   sample_rate: 16000
   max_sample_size: 250000
@@ -36,7 +36,7 @@ task:
   normalize: false # must be consistent with extractor
 
 dataset:
-  num_workers: 6
+  num_workers: 2 # Bcs I got a warning: get it back up to 6 when training for good
   max_tokens: 1400000 # This is related to the batch size
   skip_invalid_size_inputs_valid_test: true
   validate_interval: 5

--- a/examples/hubert/config/pretrain/hubert_base_librispeech_mtl.yaml
+++ b/examples/hubert/config/pretrain/hubert_base_librispeech_mtl.yaml
@@ -1,0 +1,101 @@
+# @package _group_
+
+common:
+  fp16: true
+  log_format: json
+  log_interval: 200
+  seed: 1337
+  tensorboard_logdir: tblog
+
+checkpoint:
+  save_interval_updates: 25000
+  keep_interval_updates: 1
+  no_epoch_checkpoints: true
+
+
+distributed_training:
+  ddp_backend: no_c10d
+  distributed_backend: 'nccl'
+  distributed_world_size: 1
+  distributed_port: 29671
+  nprocs_per_node: 1
+  find_unused_parameters: true
+
+task:
+  _name: hubert_mtl_pretraining
+  data: ???
+  ssl_data: ??? # Added by me for MTL config
+  label_dir: ???
+  labels: ???
+  label_rate: ${model.label_rate}
+  sample_rate: 16000
+  max_sample_size: 250000
+  min_sample_size: 32000
+  pad_audio: false
+  random_crop: true
+  normalize: false # must be consistent with extractor
+
+dataset:
+  num_workers: 6
+  max_tokens: 1400000 # This is related to the batch size
+  skip_invalid_size_inputs_valid_test: true
+  validate_interval: 5
+  validate_interval_updates: 10000
+
+criterion:
+  _name: hubert_mtl
+  pred_masked_weight: 1.0
+  pred_nomask_weight: 0.0
+  loss_weights: [10,] # TODO: change?
+  supervised_task_weight: 0.1 # Added by me for MTL config
+
+optimization:
+  max_update: 400000
+  lr: [0.0005]
+  clip_norm: 10.0
+
+optimizer:
+  _name: adam
+  adam_betas: (0.9,0.98)
+  adam_eps: 1e-06
+  weight_decay: 0.01
+
+lr_scheduler:
+  _name: polynomial_decay
+  warmup_updates: 32000
+
+model:
+  _name: hubert_mtl
+  label_rate: ???
+  skip_masked: false
+  skip_nomask: false
+  mask_prob: 0.80
+  extractor_mode: default
+  conv_feature_layers: '[(512,10,5)] + [(512,3,2)] * 4 + [(512,2,2)] * 2'
+  final_dim: 256
+  encoder_layerdrop: 0.05
+  dropout_input: 0.1
+  dropout_features: 0.1
+  dropout: 0.1
+  attention_dropout: 0.1
+  feature_grad_mult: 0.1
+  untie_final_proj: true
+  activation_dropout: 0.0
+  num_classes_supervised: 50 # Added by me for MTL config
+  proportion_supervised_data: 0.5  # Added by me for MTL config
+
+hydra:
+  job:
+    config:
+      override_dirname:
+        kv_sep: '-'
+        item_sep: '__'
+        exclude_keys:
+          - run
+          - task.data
+          - task.label_dir
+  run:
+    dir: ???
+  sweep:
+    dir: ???
+    subdir: ${hydra.job.config_name}__${hydra.job.override_dirname}

--- a/examples/hubert/config/pretrain/hubert_base_librispeech_mtl.yaml
+++ b/examples/hubert/config/pretrain/hubert_base_librispeech_mtl.yaml
@@ -72,7 +72,6 @@ model:
   mask_prob: 0.80
   extractor_mode: default
   conv_feature_layers: '[(512,10,5)] + [(512,3,2)] * 4 + [(512,2,2)] * 2'
-  final_dim: 256
   encoder_layerdrop: 0.05
   dropout_input: 0.1
   dropout_features: 0.1

--- a/examples/hubert/config/pretrain/hubert_base_librispeech_tweaked.yaml
+++ b/examples/hubert/config/pretrain/hubert_base_librispeech_tweaked.yaml
@@ -1,0 +1,97 @@
+# @package _group_
+
+common:
+  fp16: true
+  log_format: json
+  log_interval: 200
+  seed: 1337
+  tensorboard_logdir: tblog
+
+checkpoint:
+  save_interval_updates: 25000
+  keep_interval_updates: 1
+  no_epoch_checkpoints: true
+
+
+distributed_training:
+  ddp_backend: no_c10d
+  distributed_backend: 'nccl'
+  distributed_world_size: 1
+  distributed_port: 29671
+  nprocs_per_node: 1
+  find_unused_parameters: true
+
+task:
+  _name: hubert_pretraining
+  data: ???
+  label_dir: ???
+  labels: ???
+  label_rate: ${model.label_rate}
+  sample_rate: 16000
+  max_sample_size: 250000
+  min_sample_size: 32000
+  pad_audio: false
+  random_crop: true
+  normalize: false # must be consistent with extractor
+
+dataset:
+  num_workers: 6
+  max_tokens: 1400000
+  skip_invalid_size_inputs_valid_test: true
+  validate_interval: 5
+  validate_interval_updates: 10000
+
+criterion:
+  _name: hubert
+  pred_masked_weight: 1.0
+  pred_nomask_weight: 0.0
+  loss_weights: [10,]
+
+optimization:
+  max_update: 400000
+  lr: [0.0005]
+  clip_norm: 10.0
+
+optimizer:
+  _name: adam
+  adam_betas: (0.9,0.98)
+  adam_eps: 1e-06
+  weight_decay: 0.01
+
+lr_scheduler:
+  _name: polynomial_decay
+  warmup_updates: 32000
+
+model:
+  _name: hubert
+  label_rate: ???
+  skip_masked: false
+  skip_nomask: false
+  mask_prob: 0.80
+  extractor_mode: default
+  conv_feature_layers: '[(512,10,5)] + [(512,3,2)] * 4 + [(512,2,2)] * 2'
+  final_dim: 256
+  encoder_layerdrop: 0.05
+  dropout_input: 0.1
+  dropout_features: 0.1
+  dropout: 0.1
+  attention_dropout: 0.1
+  feature_grad_mult: 0.1
+  untie_final_proj: true
+  activation_dropout: 0.0
+
+hydra:
+  job:
+    config:
+      override_dirname:
+        kv_sep: '-'
+        item_sep: '__'
+        exclude_keys:
+          - run
+          - task.data
+          - task.label_dir
+  run:
+    dir: ???
+  sweep:
+    dir: ???
+    subdir: ${hydra.job.config_name}__${hydra.job.override_dirname}

--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, Optional, Union
 
 import numpy as np
 import torch
+from omegaconf import DictConfig, OmegaConf, open_dict
+
 from fairseq.data import data_utils
 from fairseq.dataclass.configs import CheckpointConfig
 from fairseq.dataclass.utils import (
@@ -27,7 +29,6 @@ from fairseq.dataclass.utils import (
 from fairseq.distributed.fully_sharded_data_parallel import FSDP, has_FSDP
 from fairseq.file_io import PathManager
 from fairseq.models import FairseqDecoder, FairseqEncoder
-from omegaconf import DictConfig, OmegaConf, open_dict
 
 logger = logging.getLogger(__name__)
 
@@ -100,9 +101,9 @@ def save_checkpoint(cfg: CheckpointConfig, trainer, epoch_itr, val_loss):
                 cfg.best_checkpoint_metric, val_loss, rand_sfx, suffix
             )
         ] = worst_best is None or is_better(val_loss, worst_best)
-    checkpoint_conds[
-        "checkpoint_last{}.pt".format(suffix)
-    ] = not cfg.no_last_checkpoints
+    checkpoint_conds["checkpoint_last{}.pt".format(suffix)] = (
+        not cfg.no_last_checkpoints
+    )
 
     extra_state = {
         "train_iterator": epoch_itr.state_dict(),
@@ -116,7 +117,9 @@ def save_checkpoint(cfg: CheckpointConfig, trainer, epoch_itr, val_loss):
     # attributes
     if hasattr(trainer.task, "get_checkpoint_dict"):
         extra_state = {**extra_state, **trainer.task.get_checkpoint_dict()}
-        logger.info(f"State of {trainer.task.__class__.__name__} is ready to be persisted with the checkpoint")
+        logger.info(
+            f"State of {trainer.task.__class__.__name__} is ready to be persisted with the checkpoint"
+        )
 
     if hasattr(save_checkpoint, "best"):
         extra_state.update({"best": save_checkpoint.best})
@@ -337,7 +340,7 @@ def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False):
         local_path = PathManager.get_local_path(path)
 
     with open(local_path, "rb") as f:
-        state = torch.load(f, map_location=torch.device("cpu"))
+        state = torch.load(f, map_location=torch.device("cpu"), weights_only=False)
 
     if "args" in state and state["args"] is not None and arg_overrides is not None:
         args = state["args"]

--- a/fairseq/criterions/hubert_mtl_criterion.py
+++ b/fairseq/criterions/hubert_mtl_criterion.py
@@ -1,0 +1,204 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import torch
+import torch.nn.functional as F
+from fairseq import utils
+from fairseq.criterions.hubert_criterion import HubertCriterion, HubertCriterionConfig
+from fairseq.logging import metrics
+from fairseq.criterions import FairseqCriterion, register_criterion
+
+# TODO: constrain the weight of the unsupervised task
+# TODO: see if I can put the supervised_task_weight in the loss_weights part instead?
+# If I change the proportion of the supervised data, I will have to account for it in the loss, since it will change the magnitude of the loss.
+# Should I divide by the number of examples when computing the loss function to circumvent this problem? Or I could keep the proprotion of 
+# supervised samples constant, but only vary the weight
+@dataclass
+class HubertMTLCriterionConfig(HubertCriterionConfig):
+    # TODO: I have defined this in two places, choose one.
+    supervised_task_weight: float = field(
+        default=0.1,
+        metadata={"help": "weight for the supervised task"},
+    )
+
+
+@register_criterion("hubert_mtl", dataclass=HubertMTLCriterionConfig)
+class HubertMTLCriterion(HubertCriterion):
+    def __init__(
+        self,
+        task,
+        pred_masked_weight,
+        pred_nomask_weight,
+        supervised_task_weight,
+        loss_weights=None,
+        log_keys=None,
+    ):
+        super().__init__(task)
+        self.supervised_task_weight = supervised_task_weight
+        self.pred_masked_weight = pred_masked_weight
+        self.pred_nomask_weight = pred_nomask_weight
+        self.loss_weights = loss_weights
+        self.log_keys = [] if log_keys is None else log_keys
+
+    
+    # TODO: should I modify the forward function of the model?
+    def forward(self, model, sample, reduce=True, log_pred=False):
+        """Compute the loss for the given sample.
+        Returns a tuple with three elements:
+        1) the loss
+        2) the sample size, which is used as the denominator for the gradient
+        3) logging outputs to display while training
+        """
+        net_output = model(target_list=sample["target_list"], **sample["net_input"])
+        loss = 0.0
+        sample_size = 0
+        logging_output = {}
+        reduction = "sum" if reduce else "none"
+
+        loss_m_list = []
+        logp_m_list = model.get_logits(net_output, True)
+        targ_m_list = model.get_targets(net_output, True)
+        assert self.pred_masked_weight == 0 or len(logp_m_list) > 0
+        for i, (logp_m, targ_m) in enumerate(zip(logp_m_list, targ_m_list)):
+            loss_m = F.cross_entropy(logp_m, targ_m, reduction=reduction)
+            loss_m_list.append(loss_m)
+            logging_output[f"loss_m_{i}"] = loss_m.detach().item()
+        if self.pred_masked_weight > 0:
+            loss += self.pred_masked_weight * sum(loss_m_list)
+            sample_size += targ_m_list[0].numel()
+
+        loss_u_list = []
+        logp_u_list = model.get_logits(net_output, False)
+        targ_u_list = model.get_targets(net_output, False)
+        assert self.pred_nomask_weight == 0 or len(logp_u_list) > 0
+        for i, (logp_u, targ_u) in enumerate(zip(logp_u_list, targ_u_list)):
+            loss_u = F.cross_entropy(logp_u, targ_u, reduction=reduction)
+            loss_u_list.append(loss_u)
+            logging_output[f"loss_u_{i}"] = loss_u.detach().item()
+        if self.pred_nomask_weight > 0:
+            loss += self.pred_nomask_weight * sum(loss_u_list)
+            sample_size += targ_u_list[0].numel()
+
+        # TODO: do it correctly
+        def compute_supervised_loss(mask_supervised: torch.Tensor, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+            loss = F.binary_cross_entropy_with_logits(logits, target=labels, reduction=None)
+            masked_loss = loss * mask_supervised
+            task_loss = torch.sum(masked_loss) / torch.count_nonzero(
+                    masked_loss
+                )
+            return task_loss
+        
+        supervised_loss = compute_supervised_loss(mask_supervised=sample["mask_supervised"], logits=model.get_supervised_logits(net_output), labels=sample["supervised_labels"])
+        loss += self.supervised_task_weight * supervised_loss
+        
+        if self.loss_weights is not None:
+            assert hasattr(model, "get_extra_losses")
+            extra_losses, names = model.get_extra_losses(net_output) #TODO: implement loss there instead?
+            if torch.is_tensor(extra_losses):
+                extra_losses = [extra_losses]
+                names = [names]
+            if len(self.loss_weights) == 1 and len(extra_losses) != 1:
+                self.loss_weights = [self.loss_weights[0]] * len(extra_losses)
+            assert len(extra_losses) == len(
+                self.loss_weights
+            ), f"{len(extra_losses)}, {len(self.loss_weights)}"
+            for p, n, coef in zip(extra_losses, names, self.loss_weights):
+                if coef != 0 and p is not None:
+                    p = coef * p.float() * sample_size
+                    loss += p
+                    logging_output[f"loss_{n}"] = p.item()
+
+        logging_output = {
+            "loss": loss.item() if reduce else loss,
+            "ntokens": sample_size,
+            "nsentences": sample["id"].numel(),
+            "sample_size": sample_size,
+            **logging_output,
+        }
+
+        for lk in self.log_keys:
+            if lk in net_output:
+                logging_output[lk] = float((net_output[lk]))
+
+        def compute_correct(logits):
+            if logits.numel() == 0:
+                return 0, 0
+            else:
+                assert logits.dim() > 1, logits.shape
+                max = logits.argmax(-1) == 0
+                min = logits.argmin(-1) == 0
+                both = max & min
+                corr = max.long().sum().item() - both.long().sum().item()
+                count = max.numel()
+                return corr, count
+
+        with torch.no_grad():
+            for i, logp_m in enumerate(logp_m_list):
+                corr_m, count_m = compute_correct(logp_m)
+                logging_output[f"correct_m_{i}"] = corr_m
+                logging_output[f"count_m_{i}"] = count_m
+
+            for i, logp_u in enumerate(logp_u_list):
+                corr_u, count_u = compute_correct(logp_u)
+                logging_output[f"correct_u_{i}"] = corr_u
+                logging_output[f"count_u_{i}"] = count_u
+
+        return loss, sample_size, logging_output
+
+    @staticmethod
+    def reduce_metrics(logging_outputs) -> None:
+        """Aggregate logging outputs from data parallel training (copied from normal cross entropy)."""
+        loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
+        ntokens = sum(log.get("ntokens", 0) for log in logging_outputs)
+        sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
+
+        metrics.log_scalar(
+            "loss", loss_sum / sample_size / math.log(2), sample_size, round=3
+        )
+        if sample_size != ntokens:
+            metrics.log_scalar(
+                "nll_loss", loss_sum / ntokens / math.log(2), ntokens, round=3
+            )
+            metrics.log_derived(
+                "ppl", lambda meters: utils.get_perplexity(meters["nll_loss"].avg)
+            )
+        else:
+            metrics.log_derived(
+                "ppl", lambda meters: utils.get_perplexity(meters["loss"].avg)
+            )
+
+        counts = {}
+        for lk in logging_outputs[0].keys():
+            if lk.startswith("count_"):
+                val = sum(log[lk] for log in logging_outputs)
+                metrics.log_scalar(lk, val)
+                counts[lk] = val
+
+        for lk in logging_outputs[0].keys():
+            if lk.startswith("loss_"):
+                val = sum(log[lk] for log in logging_outputs)
+                metrics.log_scalar(lk, val / sample_size / math.log(2), round=3)
+            elif lk.startswith("correct_"):
+                val = sum(log[lk] for log in logging_outputs)
+                metrics.log_scalar(lk, val / counts[re.sub("correct", "count", lk)])
+
+    @staticmethod
+    def aggregate_logging_outputs(logging_outputs):
+        """Aggregate logging outputs from data parallel training."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def logging_outputs_can_be_summed() -> bool:
+        """
+        Whether the logging outputs returned by `forward` can be summed
+        across workers prior to calling `reduce_metrics`. Setting this
+        to True will improves distributed training speed.
+        """
+        return False

--- a/fairseq/criterions/hubert_mtl_criterion.py
+++ b/fairseq/criterions/hubert_mtl_criterion.py
@@ -58,7 +58,11 @@ class HubertMTLCriterion(HubertCriterion):
         2) the sample size, which is used as the denominator for the gradient
         3) logging outputs to display while training
         """
-        net_output = model(target_list=sample["target_list"], **sample["net_input"])
+        net_output = model(
+            target_list=sample["target_list"],
+            is_item_annotated=sample["is_item_annotated"],
+            **sample["net_input"],
+        )
         loss = 0.0
         sample_size = 0
         logging_output = {}

--- a/fairseq/criterions/hubert_mtl_criterion.py
+++ b/fairseq/criterions/hubert_mtl_criterion.py
@@ -63,23 +63,36 @@ class HubertMTLCriterion(HubertCriterion):
         sample_size = 0
         logging_output = {}
         reduction = "sum" if reduce else "none"
-        is_sample_annotated: torch.BoolTensor = sample["is_sample_annotated"]
+        is_item_annotated = sample["is_item_annotated"]
 
         loss_m_list = []
-        logp_m_list = model.get_logits(net_output, True)[~is_sample_annotated] # TODO: is this correct??
-        targ_m_list = model.get_targets(net_output, True)[~is_sample_annotated]
+        logp_m_list = model.get_logits(net_output, True)
+        # logp_m_list = model.get_logits(net_output, True)[
+        #     ~is_item_annotated
+        # ]  # TODO: is this correct??
+        targ_m_list = model.get_targets(
+            net_output, True
+        )  # Those are only 0??? I don't get why
+        # targ_m_list = model.get_targets(net_output, True)[~is_item_annotated]
         assert self.pred_masked_weight == 0 or len(logp_m_list) > 0
         for i, (logp_m, targ_m) in enumerate(zip(logp_m_list, targ_m_list)):
-            loss_m = F.cross_entropy(logp_m, targ_m, reduction=reduction) # should I add the mask here? Did I get the reduction correctly?
+            loss_m = F.cross_entropy(
+                logp_m, targ_m, reduction=reduction
+            )  # should I add the mask here? Did I get the reduction correctly?
             loss_m_list.append(loss_m)
             logging_output[f"loss_m_{i}"] = loss_m.detach().item()
         if self.pred_masked_weight > 0:
             loss += self.pred_masked_weight * sum(loss_m_list)
-            sample_size += targ_m_list[0].numel() # TODO: what does the [0] correspond to exactly?
+            sample_size += targ_m_list[
+                0
+            ].numel()  # TODO: what does the [0] correspond to exactly?
 
         loss_u_list = []
-        logp_u_list = model.get_logits(net_output, False)[~is_sample_annotated]
-        targ_u_list = model.get_targets(net_output, False)[~is_sample_annotated]
+        logp_u_list = model.get_logits(net_output, False)
+        targ_u_list = model.get_targets(net_output, False)
+
+        # logp_u_list = model.get_logits(net_output, False)[~is_item_annotated]
+        # targ_u_list = model.get_targets(net_output, False)[~is_item_annotated]
         assert self.pred_nomask_weight == 0 or len(logp_u_list) > 0
         for i, (logp_u, targ_u) in enumerate(zip(logp_u_list, targ_u_list)):
             loss_u = F.cross_entropy(logp_u, targ_u, reduction=reduction)
@@ -108,26 +121,29 @@ class HubertMTLCriterion(HubertCriterion):
                     loss += p
                     logging_output[f"loss_{n}"] = p.item()
 
-        def compute_supervised_loss(
-            mask_supervised: torch.BoolTensor, logits: torch.Tensor, labels: torch.Tensor, reduction: Optional[str]
-        ) -> torch.Tensor:
-            labels = labels[mask_supervised]
-            logits = logits[mask_supervised]
-            masked_loss = F.binary_cross_entropy_with_logits(
-                logits, target=labels, reduction=reduction
-            )
-            return masked_loss
-        
-        supervised_loss = compute_supervised_loss(
-            mask_supervised=is_sample_annotated,
-            logits=model.get_supervised_logits(net_output),
-            labels=sample["supervised_labels"],
-        )
+        # def compute_supervised_loss(
+        #     mask_supervised: torch.BoolTensor,
+        #     logits: torch.Tensor,
+        #     labels: torch.Tensor,
+        #     reduction: Optional[str],
+        # ) -> torch.Tensor:
+        #     labels = labels[mask_supervised]
+        #     logits = logits[mask_supervised]
+        #     masked_loss = F.binary_cross_entropy_with_logits(
+        #         logits, target=labels, reduction=reduction
+        #     )
+        #     return masked_loss
 
-        # Weighted ssl and sl loss
-        ssl_task_weight = 1 - self.supervised_task_weight
-        loss = ssl_task_weight * loss + self.supervised_task_weight * supervised_loss
-        
+        # supervised_loss = compute_supervised_loss(
+        #     mask_supervised=is_item_annotated,
+        #     logits=model.get_supervised_logits(net_output),
+        #     labels=sample["supervised_labels"],
+        # )
+
+        # # Weighted ssl and sl loss
+        # ssl_task_weight = 1 - self.supervised_task_weight
+        # loss = ssl_task_weight * loss + self.supervised_task_weight * supervised_loss
+
         logging_output = {
             "loss": loss.item() if reduce else loss,
             "ntokens": sample_size,

--- a/fairseq/criterions/hubert_mtl_criterion.py
+++ b/fairseq/criterions/hubert_mtl_criterion.py
@@ -51,7 +51,6 @@ class HubertMTLCriterion(HubertCriterion):
         self.loss_weights = loss_weights
         self.log_keys = [] if log_keys is None else log_keys
 
-    # TODO: should I modify the forward function of the model?
     def forward(self, model, sample, reduce=True, log_pred=False):
         """Compute the loss for the given sample.
         Returns a tuple with three elements:
@@ -64,22 +63,23 @@ class HubertMTLCriterion(HubertCriterion):
         sample_size = 0
         logging_output = {}
         reduction = "sum" if reduce else "none"
+        is_sample_annotated: torch.BoolTensor = sample["is_sample_annotated"]
 
         loss_m_list = []
-        logp_m_list = model.get_logits(net_output, True)
-        targ_m_list = model.get_targets(net_output, True)
+        logp_m_list = model.get_logits(net_output, True)[~is_sample_annotated] # TODO: is this correct??
+        targ_m_list = model.get_targets(net_output, True)[~is_sample_annotated]
         assert self.pred_masked_weight == 0 or len(logp_m_list) > 0
         for i, (logp_m, targ_m) in enumerate(zip(logp_m_list, targ_m_list)):
-            loss_m = F.cross_entropy(logp_m, targ_m, reduction=reduction)
+            loss_m = F.cross_entropy(logp_m, targ_m, reduction=reduction) # should I add the mask here? Did I get the reduction correctly?
             loss_m_list.append(loss_m)
             logging_output[f"loss_m_{i}"] = loss_m.detach().item()
         if self.pred_masked_weight > 0:
             loss += self.pred_masked_weight * sum(loss_m_list)
-            sample_size += targ_m_list[0].numel()
+            sample_size += targ_m_list[0].numel() # TODO: what does the [0] correspond to exactly?
 
         loss_u_list = []
-        logp_u_list = model.get_logits(net_output, False)
-        targ_u_list = model.get_targets(net_output, False)
+        logp_u_list = model.get_logits(net_output, False)[~is_sample_annotated]
+        targ_u_list = model.get_targets(net_output, False)[~is_sample_annotated]
         assert self.pred_nomask_weight == 0 or len(logp_u_list) > 0
         for i, (logp_u, targ_u) in enumerate(zip(logp_u_list, targ_u_list)):
             loss_u = F.cross_entropy(logp_u, targ_u, reduction=reduction)
@@ -88,24 +88,6 @@ class HubertMTLCriterion(HubertCriterion):
         if self.pred_nomask_weight > 0:
             loss += self.pred_nomask_weight * sum(loss_u_list)
             sample_size += targ_u_list[0].numel()
-
-        # TODO: do it correctly
-        def compute_supervised_loss(
-            mask_supervised: torch.Tensor, logits: torch.Tensor, labels: torch.Tensor
-        ) -> torch.Tensor:
-            loss = F.binary_cross_entropy_with_logits(
-                logits, target=labels, reduction=None
-            )
-            masked_loss = loss * mask_supervised
-            task_loss = torch.sum(masked_loss) / torch.count_nonzero(masked_loss)
-            return task_loss
-
-        supervised_loss = compute_supervised_loss(
-            mask_supervised=sample["mask_supervised"],
-            logits=model.get_supervised_logits(net_output),
-            labels=sample["supervised_labels"],
-        )
-        loss += self.supervised_task_weight * supervised_loss
 
         if self.loss_weights is not None:
             assert hasattr(model, "get_extra_losses")
@@ -126,6 +108,26 @@ class HubertMTLCriterion(HubertCriterion):
                     loss += p
                     logging_output[f"loss_{n}"] = p.item()
 
+        def compute_supervised_loss(
+            mask_supervised: torch.BoolTensor, logits: torch.Tensor, labels: torch.Tensor, reduction: Optional[str]
+        ) -> torch.Tensor:
+            labels = labels[mask_supervised]
+            logits = logits[mask_supervised]
+            masked_loss = F.binary_cross_entropy_with_logits(
+                logits, target=labels, reduction=reduction
+            )
+            return masked_loss
+        
+        supervised_loss = compute_supervised_loss(
+            mask_supervised=is_sample_annotated,
+            logits=model.get_supervised_logits(net_output),
+            labels=sample["supervised_labels"],
+        )
+
+        # Weighted ssl and sl loss
+        ssl_task_weight = 1 - self.supervised_task_weight
+        loss = ssl_task_weight * loss + self.supervised_task_weight * supervised_loss
+        
         logging_output = {
             "loss": loss.item() if reduce else loss,
             "ntokens": sample_size,

--- a/fairseq/data/audio/hubert_dataset.py
+++ b/fairseq/data/audio/hubert_dataset.py
@@ -468,7 +468,7 @@ class HubertMTLDataset(HubertDataset):
         }
         batch = {
             "id": torch.LongTensor([s["id"] for s in samples]),
-            "is_item_annotated": is_item_annotated,
+            "is_item_annotated": torch.BoolTensor(is_item_annotated),
             "net_input": net_input,
         }
 

--- a/fairseq/models/hubert/__init__.py
+++ b/fairseq/models/hubert/__init__.py
@@ -5,3 +5,4 @@
 
 from .hubert import *  # noqa
 from .hubert_asr import *  # noqa
+from .hubert_mtl import *  # noqa

--- a/fairseq/models/hubert/hubert.py
+++ b/fairseq/models/hubert/hubert.py
@@ -415,7 +415,9 @@ class HubertModel(BaseFairseqModel):
             feat_tsz = int(targ_tsz / self.feat2tar_ratio)
             features = features[..., :feat_tsz]
         target_inds = torch.arange(feat_tsz).float() * self.feat2tar_ratio
-        target_list = [t[:, target_inds.long()] for t in target_list]
+        target_list = [
+            t[:, target_inds.long()] for t in target_list
+        ]  # will trim labels by taking one value out of 2. Why?? To align with the features I guess (but still weird)
         return features, target_list
 
     def forward_padding_mask(

--- a/fairseq/models/hubert/hubert_mtl.py
+++ b/fairseq/models/hubert/hubert_mtl.py
@@ -1,0 +1,576 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from omegaconf import II
+
+from fairseq import utils
+from fairseq.data.data_utils import compute_mask_indices
+from fairseq.data.dictionary import Dictionary
+from fairseq.dataclass import ChoiceEnum, FairseqDataclass
+from fairseq.models import BaseFairseqModel, register_model
+from fairseq.models.wav2vec.wav2vec2 import (
+    EXTRACTOR_MODE_CHOICES,
+    MASKING_DISTRIBUTION_CHOICES,
+    LAYER_TYPE_CHOICES,
+    ConvFeatureExtractionModel,
+    TransformerEncoder,
+)
+from fairseq.modules import GradMultiply, LayerNorm
+from fairseq.tasks.hubert_pretraining import (
+    HubertPretrainingConfig,
+    HubertPretrainingTask,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HubertConfig(FairseqDataclass):
+    label_rate: float = II("task.label_rate")
+
+    extractor_mode: EXTRACTOR_MODE_CHOICES = field(
+        default="default",
+        metadata={
+            "help": "mode for feature extractor. default has a single group "
+            "norm with d groups in the first conv block, whereas layer_norm "
+            "has layer norms in every block (meant to use with normalize=True)"
+        },
+    )
+    encoder_layers: int = field(
+        default=12, metadata={"help": "num encoder layers in the transformer"}
+    )
+    encoder_embed_dim: int = field(
+        default=768, metadata={"help": "encoder embedding dimension"}
+    )
+    encoder_ffn_embed_dim: int = field(
+        default=3072, metadata={"help": "encoder embedding dimension for FFN"}
+    )
+    encoder_attention_heads: int = field(
+        default=12, metadata={"help": "num encoder attention heads"}
+    )
+    activation_fn: ChoiceEnum(utils.get_available_activation_fns()) = field(
+        default="gelu", metadata={"help": "activation function to use"}
+    )
+    layer_type: LAYER_TYPE_CHOICES = field(
+        default="transformer", metadata={"help": "layer type in encoder"}
+    )
+
+    # dropouts
+    dropout: float = field(
+        default=0.1,
+        metadata={"help": "dropout probability for the transformer"},
+    )
+    attention_dropout: float = field(
+        default=0.1,
+        metadata={"help": "dropout probability for attention weights"},
+    )
+    activation_dropout: float = field(
+        default=0.0,
+        metadata={"help": "dropout probability after activation in FFN"},
+    )
+    encoder_layerdrop: float = field(
+        default=0.0,
+        metadata={"help": "probability of dropping a tarnsformer layer"},
+    )
+    dropout_input: float = field(
+        default=0.0,
+        metadata={"help": "dropout to apply to the input (after feat extr)"},
+    )
+    dropout_features: float = field(
+        default=0.0,
+        metadata={"help": "dropout to apply to the features (after feat extr)"},
+    )
+
+    final_dim: int = field(
+        default=0,
+        metadata={
+            "help": "project final representations and targets to this many "
+            "dimensions. set to encoder_embed_dim is <= 0"
+        },
+    )
+    untie_final_proj: bool = field(
+        default=False,
+        metadata={"help": "use separate projection for each target"},
+    )
+    layer_norm_first: bool = field(
+        default=False,
+        metadata={"help": "apply layernorm first in the transformer"},
+    )
+    conv_feature_layers: str = field(
+        default="[(512,10,5)] + [(512,3,2)] * 4 + [(512,2,2)] * 2",
+        metadata={
+            "help": "string describing convolutional feature extraction "
+            "layers in form of a python list that contains "
+            "[(dim, kernel_size, stride), ...]"
+        },
+    )
+    conv_bias: bool = field(
+        default=False, metadata={"help": "include bias in conv encoder"}
+    )
+    logit_temp: float = field(
+        default=0.1, metadata={"help": "temperature to divide logits by"}
+    )
+    target_glu: bool = field(
+        default=False, metadata={"help": "adds projection + glu to targets"}
+    )
+    feature_grad_mult: float = field(
+        default=1.0,
+        metadata={"help": "multiply feature extractor var grads by this"},
+    )
+
+    # masking
+    mask_length: int = field(default=10, metadata={"help": "mask length"})
+    mask_prob: float = field(
+        default=0.65,
+        metadata={"help": "probability of replacing a token with mask"},
+    )
+    mask_selection: MASKING_DISTRIBUTION_CHOICES = field(
+        default="static", metadata={"help": "how to choose mask length"}
+    )
+    mask_other: float = field(
+        default=0,
+        metadata={
+            "help": "secondary mask argument "
+            "(used for more complex distributions), "
+            "see help in compute_mask_indicesh"
+        },
+    )
+    no_mask_overlap: bool = field(
+        default=False, metadata={"help": "whether to allow masks to overlap"}
+    )
+    mask_min_space: int = field(
+        default=1,
+        metadata={"help": "min space between spans (if no overlap is enabled)"},
+    )
+
+    # channel masking
+    mask_channel_length: int = field(
+        default=10,
+        metadata={"help": "length of the mask for features (channels)"},
+    )
+    mask_channel_prob: float = field(
+        default=0.0,
+        metadata={"help": "probability of replacing a feature with 0"},
+    )
+    mask_channel_selection: MASKING_DISTRIBUTION_CHOICES = field(
+        default="static",
+        metadata={"help": "how to choose mask length for channel masking"},
+    )
+    mask_channel_other: float = field(
+        default=0,
+        metadata={
+            "help": "secondary mask argument "
+            "(used for more complex distributions), "
+            "see help in compute_mask_indicesh"
+        },
+    )
+    no_mask_channel_overlap: bool = field(
+        default=False,
+        metadata={"help": "whether to allow channel masks to overlap"},
+    )
+    mask_channel_min_space: int = field(
+        default=1,
+        metadata={"help": "min space between spans (if no overlap is enabled)"},
+    )
+
+    # positional embeddings
+    conv_pos: int = field(
+        default=128,
+        metadata={"help": "number of filters for convolutional positional embeddings"},
+    )
+    conv_pos_groups: int = field(
+        default=16,
+        metadata={"help": "number of groups for convolutional positional embedding"},
+    )
+    conv_pos_batch_norm: bool = field(
+        default=False,
+        metadata={
+            "help": "use batch norm instead of weight norm in conv_pos (for bf16 models)"
+        },
+    )
+
+    latent_temp: Tuple[float, float, float] = field(
+        default=(2, 0.5, 0.999995),
+        metadata={"help": "legacy (to be removed)"},
+    )
+
+    # loss computation
+    skip_masked: bool = field(
+        default=False,
+        metadata={"help": "skip computing losses over masked frames"},
+    )
+    skip_nomask: bool = field(
+        default=False,
+        metadata={"help": "skip computing losses over unmasked frames"},
+    )
+
+    checkpoint_activations: bool = field(
+        default=False,
+        metadata={"help": "recompute activations and save memory for extra compute"},
+    )
+
+    # FP16 optimization
+    required_seq_len_multiple: int = field(
+        default=2,
+        metadata={
+            "help": "pad the input to encoder such that the sequence length is divisible by multiple"
+        },
+    )
+
+    # Conformer
+    depthwise_conv_kernel_size: int = field(
+        default=31,
+        metadata={
+            "help": "depthwise-conv-kernel-size for convolution in conformer layer"
+        },
+    )
+    attn_type: str = field(
+        default="",
+        metadata={"help": "if espnet use ESPNET MHA"},
+    )
+    pos_enc_type: str = field(
+        default="abs",
+        metadata={"help": "Positional encoding type to use in conformer"},
+    )
+    fp16: bool = field(default=False, metadata={"help": "If fp16 is being used"})
+
+
+@register_model("hubert", dataclass=HubertConfig)
+class HubertModel(BaseFairseqModel):
+    def __init__(
+        self,
+        cfg: HubertConfig,
+        task_cfg: HubertPretrainingConfig,
+        dictionaries: List[Dictionary],
+    ) -> None:
+        super().__init__()
+        logger.info(f"HubertModel Config: {cfg}")
+
+        feature_enc_layers = eval(cfg.conv_feature_layers)  # noqa
+        self.embed = feature_enc_layers[-1][0]
+
+        self.feature_extractor = ConvFeatureExtractionModel(
+            conv_layers=feature_enc_layers,
+            dropout=0.0,
+            mode=cfg.extractor_mode,
+            conv_bias=cfg.conv_bias,
+        )
+        feature_ds_rate = np.prod([s for _, _, s in feature_enc_layers])
+        self.feat2tar_ratio = cfg.label_rate * feature_ds_rate / task_cfg.sample_rate
+
+        self.post_extract_proj = (
+            nn.Linear(self.embed, cfg.encoder_embed_dim)
+            if self.embed != cfg.encoder_embed_dim
+            else None
+        )
+
+        self.mask_prob = cfg.mask_prob
+        self.mask_selection = cfg.mask_selection
+        self.mask_other = cfg.mask_other
+        self.mask_length = cfg.mask_length
+        self.no_mask_overlap = cfg.no_mask_overlap
+        self.mask_min_space = cfg.mask_min_space
+
+        self.mask_channel_prob = cfg.mask_channel_prob
+        self.mask_channel_selection = cfg.mask_channel_selection
+        self.mask_channel_other = cfg.mask_channel_other
+        self.mask_channel_length = cfg.mask_channel_length
+        self.no_mask_channel_overlap = cfg.no_mask_channel_overlap
+        self.mask_channel_min_space = cfg.mask_channel_min_space
+
+        self.dropout_input = nn.Dropout(cfg.dropout_input)
+        self.dropout_features = nn.Dropout(cfg.dropout_features)
+
+        self.feature_grad_mult = cfg.feature_grad_mult
+        self.logit_temp = cfg.logit_temp
+        self.skip_masked = cfg.skip_masked
+        self.skip_nomask = cfg.skip_nomask
+
+        final_dim = cfg.final_dim if cfg.final_dim > 0 else cfg.encoder_embed_dim
+
+        self.mask_emb = nn.Parameter(
+            torch.FloatTensor(cfg.encoder_embed_dim).uniform_()
+        )
+
+        self.encoder = TransformerEncoder(cfg)
+        self.layer_norm = LayerNorm(self.embed)
+
+        self.target_glu = None
+        if cfg.target_glu:
+            self.target_glu = nn.Sequential(
+                nn.Linear(final_dim, final_dim * 2), nn.GLU()
+            )
+
+        self.untie_final_proj = cfg.untie_final_proj
+        if self.untie_final_proj:
+            self.final_proj = nn.Linear(
+                cfg.encoder_embed_dim, final_dim * len(dictionaries)
+            )
+        else:
+            self.final_proj = nn.Linear(cfg.encoder_embed_dim, final_dim)
+
+        # modules below are not needed during fine-tuning
+        if any([d is None for d in dictionaries]):
+            logger.info("cannot find dictionary. assume will be used for fine-tuning")
+        else:
+            self.num_classes = [len(d) for d in dictionaries]
+            self.label_embs_concat = nn.Parameter(
+                torch.FloatTensor(sum(self.num_classes), final_dim)
+            )
+            nn.init.uniform_(self.label_embs_concat)
+
+    def upgrade_state_dict_named(self, state_dict, name):
+        """Upgrade a (possibly old) state dict for new versions of fairseq."""
+
+        super().upgrade_state_dict_named(state_dict, name)
+        return state_dict
+
+    @classmethod
+    def build_model(cls, cfg: HubertConfig, task: HubertPretrainingTask):
+        """Build a new model instance."""
+
+        model = HubertModel(cfg, task.cfg, task.dictionaries)
+        return model
+
+    def apply_mask(self, x, padding_mask, target_list):
+        B, T, C = x.shape
+        if self.mask_prob > 0:
+            mask_indices = compute_mask_indices(
+                (B, T),
+                padding_mask,
+                self.mask_prob,
+                self.mask_length,
+                self.mask_selection,
+                self.mask_other,
+                min_masks=2,
+                no_overlap=self.no_mask_overlap,
+                min_space=self.mask_min_space,
+            )
+            mask_indices = torch.from_numpy(mask_indices).to(x.device)
+            x[mask_indices] = self.mask_emb
+        else:
+            mask_indices = None
+
+        if self.mask_channel_prob > 0:
+            mask_channel_indices = compute_mask_indices(
+                (B, C),
+                None,
+                self.mask_channel_prob,
+                self.mask_channel_length,
+                self.mask_channel_selection,
+                self.mask_channel_other,
+                no_overlap=self.no_mask_channel_overlap,
+                min_space=self.mask_channel_min_space,
+            )
+            mask_channel_indices = (
+                torch.from_numpy(mask_channel_indices)
+                .to(x.device)
+                .unsqueeze(1)
+                .expand(-1, T, -1)
+            )
+            x[mask_channel_indices] = 0
+
+        return x, mask_indices
+
+    def compute_nce(self, x, pos, negs):
+        neg_is_pos = (pos == negs).all(-1)
+        pos = pos.unsqueeze(0)
+        targets = torch.cat([pos, negs], dim=0)
+
+        logits = torch.cosine_similarity(x.float(), targets.float(), dim=-1).type_as(x)
+        logits /= self.logit_temp
+        if neg_is_pos.any():
+            logits[1:][neg_is_pos] = float("-inf")
+        logits = logits.transpose(0, 1)  # (num_x, num_cls+1)
+        return logits
+
+    def forward_features(self, source: torch.Tensor) -> torch.Tensor:
+        if self.feature_grad_mult > 0:
+            features = self.feature_extractor(source)
+            if self.feature_grad_mult != 1.0:
+                features = GradMultiply.apply(features, self.feature_grad_mult)
+        else:
+            with torch.no_grad():
+                features = self.feature_extractor(source)
+        return features
+
+    def forward_targets(
+        self,
+        features: torch.Tensor,
+        target_list: List[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Trim features to ensure labels exist and then get aligned labels
+        feat_tsz = features.size(2)
+        targ_tsz = min([t.size(1) for t in target_list])
+        if self.feat2tar_ratio * feat_tsz > targ_tsz:
+            feat_tsz = int(targ_tsz / self.feat2tar_ratio)
+            features = features[..., :feat_tsz]
+        target_inds = torch.arange(feat_tsz).float() * self.feat2tar_ratio
+        target_list = [t[:, target_inds.long()] for t in target_list]
+        return features, target_list
+
+    def forward_padding_mask(
+        self,
+        features: torch.Tensor,
+        padding_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        extra = padding_mask.size(1) % features.size(1)
+        if extra > 0:
+            padding_mask = padding_mask[:, :-extra]
+        padding_mask = padding_mask.view(padding_mask.size(0), features.size(1), -1)
+        padding_mask = padding_mask.all(-1)
+        return padding_mask
+
+    def forward(
+        self,
+        source: torch.Tensor,
+        target_list: Optional[List[torch.Tensor]] = None,
+        padding_mask: Optional[torch.Tensor] = None,
+        mask: bool = True,
+        features_only: bool = False,
+        output_layer: Optional[int] = None,
+    ) -> Dict[str, torch.Tensor]:
+        """output layer is 1-based"""
+        features = self.forward_features(source)
+        if target_list is not None:
+            features, target_list = self.forward_targets(features, target_list)
+
+        features_pen = features.float().pow(2).mean()
+
+        features = features.transpose(1, 2)
+        features = self.layer_norm(features)
+        unmasked_features = features.clone()
+
+        if padding_mask is not None:
+            padding_mask = self.forward_padding_mask(features, padding_mask)
+
+        if self.post_extract_proj is not None:
+            features = self.post_extract_proj(features)
+
+        features = self.dropout_input(features)
+        unmasked_features = self.dropout_features(unmasked_features)
+
+        if mask:
+            x, mask_indices = self.apply_mask(features, padding_mask, target_list)
+        else:
+            x = features
+            mask_indices = None
+
+        # feature: (B, T, D), float
+        # target: (B, T), long
+        # x: (B, T, D), float
+        # padding_mask: (B, T), bool
+        # mask_indices: (B, T), bool
+        x, _ = self.encoder(
+            x,
+            padding_mask=padding_mask,
+            layer=None if output_layer is None else output_layer - 1,
+        )
+
+        if features_only:
+            return {"x": x, "padding_mask": padding_mask, "features": features}
+
+        def compute_pred(proj_x, target, label_embs):
+            # compute logits for the i-th label set
+            y = torch.index_select(label_embs, 0, target.long())
+            negs = label_embs.unsqueeze(1).expand(-1, proj_x.size(0), -1)
+            if self.target_glu:
+                y = self.target_glu(y)
+                negs = self.target_glu(negs)
+            # proj_x: (S, D)
+            # y: (S, D)
+            # negs: (Neg, S, D)
+            return self.compute_nce(proj_x, y, negs)
+
+        label_embs_list = self.label_embs_concat.split(self.num_classes, 0)
+
+        if not self.skip_masked:
+            masked_indices = torch.logical_and(~padding_mask, mask_indices)
+            proj_x_m = self.final_proj(x[masked_indices])
+            if self.untie_final_proj:
+                proj_x_m_list = proj_x_m.chunk(len(target_list), dim=-1)
+            else:
+                proj_x_m_list = [proj_x_m for _ in range(len(target_list))]
+            logit_m_list = [
+                compute_pred(proj_x_m, t[masked_indices], label_embs_list[i])
+                for i, (proj_x_m, t) in enumerate(zip(proj_x_m_list, target_list))
+            ]
+        else:
+            logit_m_list = [None for _ in target_list]
+
+        if not self.skip_nomask:
+            nomask_indices = torch.logical_and(~padding_mask, ~mask_indices)
+            proj_x_u = self.final_proj(x[nomask_indices])
+            if self.untie_final_proj:
+                proj_x_u_list = proj_x_u.chunk(len(target_list), dim=-1)
+            else:
+                proj_x_u_list = [proj_x_u for _ in range(len(target_list))]
+
+            logit_u_list = [
+                compute_pred(proj_x_u, t[nomask_indices], label_embs_list[i])
+                for i, (proj_x_u, t) in enumerate(zip(proj_x_u_list, target_list))
+            ]
+        else:
+            logit_u_list = [None for _ in target_list]
+
+        result = {
+            "logit_m_list": logit_m_list,
+            "logit_u_list": logit_u_list,
+            "padding_mask": padding_mask,
+            "features_pen": features_pen,
+        }
+        return result
+
+    def extract_features(
+        self,
+        source: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        mask: bool = False,
+        ret_conv: bool = False,
+        output_layer: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        res = self.forward(
+            source,
+            padding_mask=padding_mask,
+            mask=mask,
+            features_only=True,
+            output_layer=output_layer,
+        )
+        feature = res["features"] if ret_conv else res["x"]
+        return feature, res["padding_mask"]
+
+    def get_logits(self, net_output, is_masked=True):
+        if is_masked:
+            logits_list = net_output["logit_m_list"]
+        else:
+            logits_list = net_output["logit_u_list"]
+        logits_list = [x.float() for x in logits_list if x is not None]
+        return logits_list
+
+    def get_targets(self, net_output, is_masked=True):
+        logits_list = self.get_logits(net_output, is_masked)
+        targets_list = [x.new_zeros(x.size(0), dtype=torch.long) for x in logits_list]
+        return targets_list
+
+    def get_extra_losses(self, net_output):
+        extra_losses = []
+        names = []
+
+        if "features_pen" in net_output:
+            extra_losses.append(net_output["features_pen"])
+            names.append("features_pen")
+
+        return extra_losses, names
+
+    def remove_pretraining_modules(self):
+        self.target_glu = None
+        self.final_proj = None

--- a/fairseq/models/hubert/hubert_mtl.py
+++ b/fairseq/models/hubert/hubert_mtl.py
@@ -40,11 +40,11 @@ logger = logging.getLogger(__name__)
 class HubertMTLConfig(HubertConfig):
     # balance between the supervised and self-supervised tasks
     proportion_supervised_data: float = field(
-        default=0.1,
+        default=0.5,
         metadata={"help": "the proportion of supervised data in each training batch"},
     )
     num_classes_supervised: int = field(
-        default=5,
+        default=45,
         metadata={"help": "the number of classes included in the supervised task"},
     )
 
@@ -163,9 +163,9 @@ class HubertMTLModel(HubertModel):
 
         # supervised part (will give an output for everything, even for the parts without labels)
         x_mean = torch.mean(
-            x
+            x, dim=1
         )  # TODO: should we max pool instead? I guess mean is better because the vocalisations are longer than 25 ms?
-        logits_supervised = self.final_proj_supervised(x)
+        logits_supervised = self.final_proj_supervised(x_mean)
 
         result = {
             "logit_m_list": logit_m_list,

--- a/fairseq/models/hubert/hubert_mtl.py
+++ b/fairseq/models/hubert/hubert_mtl.py
@@ -17,6 +17,7 @@ from fairseq.data.data_utils import compute_mask_indices
 from fairseq.data.dictionary import Dictionary
 from fairseq.dataclass import ChoiceEnum, FairseqDataclass
 from fairseq.models import BaseFairseqModel, register_model
+from fairseq.models.hubert.hubert import HubertModel
 from fairseq.models.wav2vec.wav2vec2 import (
     EXTRACTOR_MODE_CHOICES,
     MASKING_DISTRIBUTION_CHOICES,
@@ -24,411 +25,39 @@ from fairseq.models.wav2vec.wav2vec2 import (
     ConvFeatureExtractionModel,
     TransformerEncoder,
 )
+from fairseq.models.hubert import HubertConfig
 from fairseq.modules import GradMultiply, LayerNorm
-from fairseq.tasks.hubert_pretraining import (
-    HubertPretrainingConfig,
-    HubertPretrainingTask,
-)
-
+from fairseq.tasks.hubert_mtl_pretraining import HubertMTLPretrainingConfig, HubertMTLPretrainingTask
 logger = logging.getLogger(__name__)
 
-
+#TODO: find the number of supervised classes with another way
 @dataclass
-class HubertConfig(FairseqDataclass):
-    label_rate: float = II("task.label_rate")
+class HubertMTLConfig(HubertConfig):
+    # balance between the supervised and self-supervised tasks
+    proportion_supervised_data: float = field(
+        default=0.1, metadata={"help": "the proportion of supervised data in each training batch"}
+    )
+    num_classes_supervised: int = field(default=5, metadata={"help": "the number of classes included in the supervised task"})
 
-    extractor_mode: EXTRACTOR_MODE_CHOICES = field(
-        default="default",
-        metadata={
-            "help": "mode for feature extractor. default has a single group "
-            "norm with d groups in the first conv block, whereas layer_norm "
-            "has layer norms in every block (meant to use with normalize=True)"
-        },
-    )
-    encoder_layers: int = field(
-        default=12, metadata={"help": "num encoder layers in the transformer"}
-    )
-    encoder_embed_dim: int = field(
-        default=768, metadata={"help": "encoder embedding dimension"}
-    )
-    encoder_ffn_embed_dim: int = field(
-        default=3072, metadata={"help": "encoder embedding dimension for FFN"}
-    )
-    encoder_attention_heads: int = field(
-        default=12, metadata={"help": "num encoder attention heads"}
-    )
-    activation_fn: ChoiceEnum(utils.get_available_activation_fns()) = field(
-        default="gelu", metadata={"help": "activation function to use"}
-    )
-    layer_type: LAYER_TYPE_CHOICES = field(
-        default="transformer", metadata={"help": "layer type in encoder"}
-    )
-
-    # dropouts
-    dropout: float = field(
-        default=0.1,
-        metadata={"help": "dropout probability for the transformer"},
-    )
-    attention_dropout: float = field(
-        default=0.1,
-        metadata={"help": "dropout probability for attention weights"},
-    )
-    activation_dropout: float = field(
-        default=0.0,
-        metadata={"help": "dropout probability after activation in FFN"},
-    )
-    encoder_layerdrop: float = field(
-        default=0.0,
-        metadata={"help": "probability of dropping a tarnsformer layer"},
-    )
-    dropout_input: float = field(
-        default=0.0,
-        metadata={"help": "dropout to apply to the input (after feat extr)"},
-    )
-    dropout_features: float = field(
-        default=0.0,
-        metadata={"help": "dropout to apply to the features (after feat extr)"},
-    )
-
-    final_dim: int = field(
-        default=0,
-        metadata={
-            "help": "project final representations and targets to this many "
-            "dimensions. set to encoder_embed_dim is <= 0"
-        },
-    )
-    untie_final_proj: bool = field(
-        default=False,
-        metadata={"help": "use separate projection for each target"},
-    )
-    layer_norm_first: bool = field(
-        default=False,
-        metadata={"help": "apply layernorm first in the transformer"},
-    )
-    conv_feature_layers: str = field(
-        default="[(512,10,5)] + [(512,3,2)] * 4 + [(512,2,2)] * 2",
-        metadata={
-            "help": "string describing convolutional feature extraction "
-            "layers in form of a python list that contains "
-            "[(dim, kernel_size, stride), ...]"
-        },
-    )
-    conv_bias: bool = field(
-        default=False, metadata={"help": "include bias in conv encoder"}
-    )
-    logit_temp: float = field(
-        default=0.1, metadata={"help": "temperature to divide logits by"}
-    )
-    target_glu: bool = field(
-        default=False, metadata={"help": "adds projection + glu to targets"}
-    )
-    feature_grad_mult: float = field(
-        default=1.0,
-        metadata={"help": "multiply feature extractor var grads by this"},
-    )
-
-    # masking
-    mask_length: int = field(default=10, metadata={"help": "mask length"})
-    mask_prob: float = field(
-        default=0.65,
-        metadata={"help": "probability of replacing a token with mask"},
-    )
-    mask_selection: MASKING_DISTRIBUTION_CHOICES = field(
-        default="static", metadata={"help": "how to choose mask length"}
-    )
-    mask_other: float = field(
-        default=0,
-        metadata={
-            "help": "secondary mask argument "
-            "(used for more complex distributions), "
-            "see help in compute_mask_indicesh"
-        },
-    )
-    no_mask_overlap: bool = field(
-        default=False, metadata={"help": "whether to allow masks to overlap"}
-    )
-    mask_min_space: int = field(
-        default=1,
-        metadata={"help": "min space between spans (if no overlap is enabled)"},
-    )
-
-    # channel masking
-    mask_channel_length: int = field(
-        default=10,
-        metadata={"help": "length of the mask for features (channels)"},
-    )
-    mask_channel_prob: float = field(
-        default=0.0,
-        metadata={"help": "probability of replacing a feature with 0"},
-    )
-    mask_channel_selection: MASKING_DISTRIBUTION_CHOICES = field(
-        default="static",
-        metadata={"help": "how to choose mask length for channel masking"},
-    )
-    mask_channel_other: float = field(
-        default=0,
-        metadata={
-            "help": "secondary mask argument "
-            "(used for more complex distributions), "
-            "see help in compute_mask_indicesh"
-        },
-    )
-    no_mask_channel_overlap: bool = field(
-        default=False,
-        metadata={"help": "whether to allow channel masks to overlap"},
-    )
-    mask_channel_min_space: int = field(
-        default=1,
-        metadata={"help": "min space between spans (if no overlap is enabled)"},
-    )
-
-    # positional embeddings
-    conv_pos: int = field(
-        default=128,
-        metadata={"help": "number of filters for convolutional positional embeddings"},
-    )
-    conv_pos_groups: int = field(
-        default=16,
-        metadata={"help": "number of groups for convolutional positional embedding"},
-    )
-    conv_pos_batch_norm: bool = field(
-        default=False,
-        metadata={
-            "help": "use batch norm instead of weight norm in conv_pos (for bf16 models)"
-        },
-    )
-
-    latent_temp: Tuple[float, float, float] = field(
-        default=(2, 0.5, 0.999995),
-        metadata={"help": "legacy (to be removed)"},
-    )
-
-    # loss computation
-    skip_masked: bool = field(
-        default=False,
-        metadata={"help": "skip computing losses over masked frames"},
-    )
-    skip_nomask: bool = field(
-        default=False,
-        metadata={"help": "skip computing losses over unmasked frames"},
-    )
-
-    checkpoint_activations: bool = field(
-        default=False,
-        metadata={"help": "recompute activations and save memory for extra compute"},
-    )
-
-    # FP16 optimization
-    required_seq_len_multiple: int = field(
-        default=2,
-        metadata={
-            "help": "pad the input to encoder such that the sequence length is divisible by multiple"
-        },
-    )
-
-    # Conformer
-    depthwise_conv_kernel_size: int = field(
-        default=31,
-        metadata={
-            "help": "depthwise-conv-kernel-size for convolution in conformer layer"
-        },
-    )
-    attn_type: str = field(
-        default="",
-        metadata={"help": "if espnet use ESPNET MHA"},
-    )
-    pos_enc_type: str = field(
-        default="abs",
-        metadata={"help": "Positional encoding type to use in conformer"},
-    )
-    fp16: bool = field(default=False, metadata={"help": "If fp16 is being used"})
-
-
-@register_model("hubert", dataclass=HubertConfig)
-class HubertModel(BaseFairseqModel):
+@register_model("hubert_mtl", dataclass=HubertMTLConfig)
+class HubertMTLModel(HubertModel):
     def __init__(
         self,
-        cfg: HubertConfig,
-        task_cfg: HubertPretrainingConfig,
+        cfg: HubertMTLConfig,
+        task_cfg: HubertMTLPretrainingConfig,
         dictionaries: List[Dictionary],
     ) -> None:
-        super().__init__()
-        logger.info(f"HubertModel Config: {cfg}")
-
-        feature_enc_layers = eval(cfg.conv_feature_layers)  # noqa
-        self.embed = feature_enc_layers[-1][0]
-
-        self.feature_extractor = ConvFeatureExtractionModel(
-            conv_layers=feature_enc_layers,
-            dropout=0.0,
-            mode=cfg.extractor_mode,
-            conv_bias=cfg.conv_bias,
-        )
-        feature_ds_rate = np.prod([s for _, _, s in feature_enc_layers])
-        self.feat2tar_ratio = cfg.label_rate * feature_ds_rate / task_cfg.sample_rate
-
-        self.post_extract_proj = (
-            nn.Linear(self.embed, cfg.encoder_embed_dim)
-            if self.embed != cfg.encoder_embed_dim
-            else None
-        )
-
-        self.mask_prob = cfg.mask_prob
-        self.mask_selection = cfg.mask_selection
-        self.mask_other = cfg.mask_other
-        self.mask_length = cfg.mask_length
-        self.no_mask_overlap = cfg.no_mask_overlap
-        self.mask_min_space = cfg.mask_min_space
-
-        self.mask_channel_prob = cfg.mask_channel_prob
-        self.mask_channel_selection = cfg.mask_channel_selection
-        self.mask_channel_other = cfg.mask_channel_other
-        self.mask_channel_length = cfg.mask_channel_length
-        self.no_mask_channel_overlap = cfg.no_mask_channel_overlap
-        self.mask_channel_min_space = cfg.mask_channel_min_space
-
-        self.dropout_input = nn.Dropout(cfg.dropout_input)
-        self.dropout_features = nn.Dropout(cfg.dropout_features)
-
-        self.feature_grad_mult = cfg.feature_grad_mult
-        self.logit_temp = cfg.logit_temp
-        self.skip_masked = cfg.skip_masked
-        self.skip_nomask = cfg.skip_nomask
-
+        super().__init__(cfg, task_cfg, dictionaries)
+        
         final_dim = cfg.final_dim if cfg.final_dim > 0 else cfg.encoder_embed_dim
-
-        self.mask_emb = nn.Parameter(
-            torch.FloatTensor(cfg.encoder_embed_dim).uniform_()
-        )
-
-        self.encoder = TransformerEncoder(cfg)
-        self.layer_norm = LayerNorm(self.embed)
-
-        self.target_glu = None
-        if cfg.target_glu:
-            self.target_glu = nn.Sequential(
-                nn.Linear(final_dim, final_dim * 2), nn.GLU()
-            )
-
-        self.untie_final_proj = cfg.untie_final_proj
-        if self.untie_final_proj:
-            self.final_proj = nn.Linear(
-                cfg.encoder_embed_dim, final_dim * len(dictionaries)
-            )
-        else:
-            self.final_proj = nn.Linear(cfg.encoder_embed_dim, final_dim)
-
-        # modules below are not needed during fine-tuning
-        if any([d is None for d in dictionaries]):
-            logger.info("cannot find dictionary. assume will be used for fine-tuning")
-        else:
-            self.num_classes = [len(d) for d in dictionaries]
-            self.label_embs_concat = nn.Parameter(
-                torch.FloatTensor(sum(self.num_classes), final_dim)
-            )
-            nn.init.uniform_(self.label_embs_concat)
-
-    def upgrade_state_dict_named(self, state_dict, name):
-        """Upgrade a (possibly old) state dict for new versions of fairseq."""
-
-        super().upgrade_state_dict_named(state_dict, name)
-        return state_dict
+        self.final_proj_supervised = nn.Linear(final_dim, cfg.num_classes_supervised)
 
     @classmethod
-    def build_model(cls, cfg: HubertConfig, task: HubertPretrainingTask):
+    def build_model(cls, cfg: HubertMTLConfig, task: HubertMTLPretrainingTask):
         """Build a new model instance."""
 
-        model = HubertModel(cfg, task.cfg, task.dictionaries)
+        model = HubertMTLModel(cfg, task.cfg, task.dictionaries)
         return model
-
-    def apply_mask(self, x, padding_mask, target_list):
-        B, T, C = x.shape
-        if self.mask_prob > 0:
-            mask_indices = compute_mask_indices(
-                (B, T),
-                padding_mask,
-                self.mask_prob,
-                self.mask_length,
-                self.mask_selection,
-                self.mask_other,
-                min_masks=2,
-                no_overlap=self.no_mask_overlap,
-                min_space=self.mask_min_space,
-            )
-            mask_indices = torch.from_numpy(mask_indices).to(x.device)
-            x[mask_indices] = self.mask_emb
-        else:
-            mask_indices = None
-
-        if self.mask_channel_prob > 0:
-            mask_channel_indices = compute_mask_indices(
-                (B, C),
-                None,
-                self.mask_channel_prob,
-                self.mask_channel_length,
-                self.mask_channel_selection,
-                self.mask_channel_other,
-                no_overlap=self.no_mask_channel_overlap,
-                min_space=self.mask_channel_min_space,
-            )
-            mask_channel_indices = (
-                torch.from_numpy(mask_channel_indices)
-                .to(x.device)
-                .unsqueeze(1)
-                .expand(-1, T, -1)
-            )
-            x[mask_channel_indices] = 0
-
-        return x, mask_indices
-
-    def compute_nce(self, x, pos, negs):
-        neg_is_pos = (pos == negs).all(-1)
-        pos = pos.unsqueeze(0)
-        targets = torch.cat([pos, negs], dim=0)
-
-        logits = torch.cosine_similarity(x.float(), targets.float(), dim=-1).type_as(x)
-        logits /= self.logit_temp
-        if neg_is_pos.any():
-            logits[1:][neg_is_pos] = float("-inf")
-        logits = logits.transpose(0, 1)  # (num_x, num_cls+1)
-        return logits
-
-    def forward_features(self, source: torch.Tensor) -> torch.Tensor:
-        if self.feature_grad_mult > 0:
-            features = self.feature_extractor(source)
-            if self.feature_grad_mult != 1.0:
-                features = GradMultiply.apply(features, self.feature_grad_mult)
-        else:
-            with torch.no_grad():
-                features = self.feature_extractor(source)
-        return features
-
-    def forward_targets(
-        self,
-        features: torch.Tensor,
-        target_list: List[torch.Tensor],
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # Trim features to ensure labels exist and then get aligned labels
-        feat_tsz = features.size(2)
-        targ_tsz = min([t.size(1) for t in target_list])
-        if self.feat2tar_ratio * feat_tsz > targ_tsz:
-            feat_tsz = int(targ_tsz / self.feat2tar_ratio)
-            features = features[..., :feat_tsz]
-        target_inds = torch.arange(feat_tsz).float() * self.feat2tar_ratio
-        target_list = [t[:, target_inds.long()] for t in target_list]
-        return features, target_list
-
-    def forward_padding_mask(
-        self,
-        features: torch.Tensor,
-        padding_mask: torch.Tensor,
-    ) -> torch.Tensor:
-        extra = padding_mask.size(1) % features.size(1)
-        if extra > 0:
-            padding_mask = padding_mask[:, :-extra]
-        padding_mask = padding_mask.view(padding_mask.size(0), features.size(1), -1)
-        padding_mask = padding_mask.all(-1)
-        return padding_mask
 
     def forward(
         self,
@@ -522,55 +151,24 @@ class HubertModel(BaseFairseqModel):
         else:
             logit_u_list = [None for _ in target_list]
 
+
+        # supervised part (will give an output for everything, even for the parts without labels)
+        x_mean = torch.mean(x) #TODO: should we max pool instead? I guess mean is better because the vocalisations are longer than 25 ms?
+        logits_supervised = self.final_proj_supervised(x)
+
         result = {
             "logit_m_list": logit_m_list,
             "logit_u_list": logit_u_list,
             "padding_mask": padding_mask,
             "features_pen": features_pen,
+            "logits_supervised": logits_supervised
         }
         return result
-
-    def extract_features(
-        self,
-        source: torch.Tensor,
-        padding_mask: Optional[torch.Tensor] = None,
-        mask: bool = False,
-        ret_conv: bool = False,
-        output_layer: Optional[int] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        res = self.forward(
-            source,
-            padding_mask=padding_mask,
-            mask=mask,
-            features_only=True,
-            output_layer=output_layer,
-        )
-        feature = res["features"] if ret_conv else res["x"]
-        return feature, res["padding_mask"]
-
-    def get_logits(self, net_output, is_masked=True):
-        if is_masked:
-            logits_list = net_output["logit_m_list"]
-        else:
-            logits_list = net_output["logit_u_list"]
-        logits_list = [x.float() for x in logits_list if x is not None]
-        return logits_list
-
-    def get_targets(self, net_output, is_masked=True):
-        logits_list = self.get_logits(net_output, is_masked)
-        targets_list = [x.new_zeros(x.size(0), dtype=torch.long) for x in logits_list]
-        return targets_list
-
-    def get_extra_losses(self, net_output):
-        extra_losses = []
-        names = []
-
-        if "features_pen" in net_output:
-            extra_losses.append(net_output["features_pen"])
-            names.append("features_pen")
-
-        return extra_losses, names
-
+    
+    def get_supervised_logits(self, net_output):
+        return net_output["logits_supervised"]
+    
     def remove_pretraining_modules(self):
         self.target_glu = None
         self.final_proj = None
+        self.final_proj_supervised = None

--- a/fairseq/tasks/hubert_mtl_pretraining.py
+++ b/fairseq/tasks/hubert_mtl_pretraining.py
@@ -183,7 +183,7 @@ class HubertMTLPretrainingTask(HubertPretrainingTask):
             # TODO: see if this is what was expected
             batches = UnevenBatchSampler(
                 len(dataset),
-                batch_size=64,  # TODO: use max_tokens somehow instead or define the batch size in the config
+                batch_size=8,  # TODO: use max_tokens somehow instead or define the batch size in the config
                 num_samples_unlabelled_dataset=dataset.ssl_num_samples,
             )
             return batches

--- a/fairseq/tasks/hubert_mtl_pretraining.py
+++ b/fairseq/tasks/hubert_mtl_pretraining.py
@@ -7,11 +7,13 @@
 
 import logging
 from dataclasses import dataclass, field
+from typing import List, Optional
 
 from omegaconf import MISSING
 
 from fairseq.data import FairseqDataset, data_utils, iterators
 from fairseq.data.audio.hubert_dataset import HubertMTLDataset, UnevenBatchSampler
+from fairseq.dataclass.configs import FairseqDataclass
 from fairseq.tasks import register_task
 from fairseq.tasks.hubert_pretraining import (
     HubertPretrainingConfig,
@@ -25,11 +27,9 @@ logger = logging.getLogger(__name__)
 @dataclass
 class HubertMTLPretrainingConfig(HubertPretrainingConfig):
     # we want to get the number of ssl examples for the dataset to know where the border beterrn the ssl and the supervised data is
-    ssl_data: str = (
-        field(
-            default=MISSING,
-            metadata={"help": "path to data directory containing the the ssl data"},
-        ),
+    ssl_data: str = field(
+        default=MISSING,
+        metadata={"help": "path to data directory containing the the ssl data"},
     )
 
 

--- a/fairseq/tasks/hubert_mtl_pretraining.py
+++ b/fairseq/tasks/hubert_mtl_pretraining.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+
+import logging
+import sys
+from typing import List, Tuple
+
+import numpy as np
+
+from dataclasses import dataclass, field
+from fairseq.data import HubertDataset
+from fairseq.tasks.hubert_pretraining import HubertPretrainingConfig, HubertPretrainingTask, LabelEncoder
+from fairseq.tasks import register_task
+from omegaconf import MISSING
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HubertMTLPretrainingConfig(HubertPretrainingConfig):
+    data_supervised: str = field(default=MISSING, metadata={"help": "path to supervised data directory"})
+    
+    labels_dir_supervised: List[str] = field(
+        default_factory=lambda: ["ltr"],
+        metadata={
+            "help": (
+                "labels directory for the supervised task"
+            )
+        },
+    )
+
+
+@register_task("hubert_mtl_pretraining", dataclass=HubertMTLPretrainingConfig)
+class HubertMTLPretrainingTask(HubertPretrainingTask):
+
+    cfg: HubertMTLPretrainingConfig
+
+    def __init__(
+        self,
+        cfg: HubertMTLPretrainingConfig,
+    ) -> None:
+        super().__init__(cfg)
+
+    @classmethod
+    def setup_task(
+        cls, cfg: HubertMTLPretrainingConfig, **kwargs
+    ) -> "HubertMTLPretrainingTask":
+        return cls(cfg)
+
+    
+    # TODO: only overwrite the load_dataset function with a supervised=False/true kwarg to avoid boilerplate code?
+    def load_supervised_dataset(self, split: str, **kwargs) -> None:
+        manifest = f"{self.cfg.data_supervised}/{split}.tsv"
+        dicts = [self.target_dictionary] if self.cfg.fine_tuning else self.dictionaries
+        pad_list = [dict.pad() for dict in dicts]
+        eos_list = [dict.eos() for dict in dicts]
+        procs = [LabelEncoder(dict) for dict in dicts] # TODO: change that one
+        paths = [f"{self.cfg.labels_dir_supervised}/{split}.{l}" for l in self.cfg.labels] # TODO: change that one to align with the unsupervised labels paths
+
+        # hubert v1: pad_audio=True, random_crop=False;
+        self.datasets[split] = HubertDataset(
+            manifest,
+            sample_rate=self.cfg.sample_rate,
+            label_paths=paths,
+            label_rates=self.cfg.label_rate,
+            pad_list=pad_list,
+            eos_list=eos_list,
+            label_processors=procs,
+            max_keep_sample_size=self.cfg.max_keep_size,
+            min_keep_sample_size=self.cfg.min_sample_size,
+            max_sample_size=self.cfg.max_sample_size,
+            pad_audio=self.cfg.pad_audio,
+            normalize=self.cfg.normalize,
+            store_labels=False,
+            random_crop=self.cfg.random_crop,
+            single_target=self.cfg.single_target,
+        )

--- a/fairseq/tasks/hubert_mtl_pretraining.py
+++ b/fairseq/tasks/hubert_mtl_pretraining.py
@@ -179,6 +179,8 @@ class HubertMTLPretrainingTask(HubertPretrainingTask):
             #     )
 
             # create mini-batches with given size constraints
+
+            # TODO: see if this is what was expected
             batches = UnevenBatchSampler(
                 len(self.dataset),
                 num_samples_unlabelled_dataset=self.dataset.ssl_num_samples,

--- a/fairseq/tasks/hubert_mtl_pretraining.py
+++ b/fairseq/tasks/hubert_mtl_pretraining.py
@@ -6,31 +6,30 @@
 # can be found in the PATENTS file in the same directory.
 
 import logging
-import sys
-from typing import List, Tuple
-
-import numpy as np
-
 from dataclasses import dataclass, field
-from fairseq.data import HubertDataset
-from fairseq.tasks.hubert_pretraining import HubertPretrainingConfig, HubertPretrainingTask, LabelEncoder
-from fairseq.tasks import register_task
+
 from omegaconf import MISSING
+
+from fairseq.data import FairseqDataset, data_utils, iterators
+from fairseq.data.audio.hubert_dataset import HubertMTLDataset, UnevenBatchSampler
+from fairseq.tasks import register_task
+from fairseq.tasks.hubert_pretraining import (
+    HubertPretrainingConfig,
+    HubertPretrainingTask,
+    LabelEncoder,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class HubertMTLPretrainingConfig(HubertPretrainingConfig):
-    data_supervised: str = field(default=MISSING, metadata={"help": "path to supervised data directory"})
-    
-    labels_dir_supervised: List[str] = field(
-        default_factory=lambda: ["ltr"],
-        metadata={
-            "help": (
-                "labels directory for the supervised task"
-            )
-        },
+    # we want to get the number of ssl examples for the dataset to know where the border beterrn the ssl and the supervised data is
+    ssl_data: str = (
+        field(
+            default=MISSING,
+            metadata={"help": "path to data directory containing the the ssl data"},
+        ),
     )
 
 
@@ -51,22 +50,28 @@ class HubertMTLPretrainingTask(HubertPretrainingTask):
     ) -> "HubertMTLPretrainingTask":
         return cls(cfg)
 
-    
-    # TODO: only overwrite the load_dataset function with a supervised=False/true kwarg to avoid boilerplate code?
-    def load_supervised_dataset(self, split: str, **kwargs) -> None:
-        manifest = f"{self.cfg.data_supervised}/{split}.tsv"
+    # TODO: check and test that!!!
+    def _get_size_ssl_dataset(self, split: str) -> int:
+        with open(f"{self.cfg.ssl_data}/{split}.tsv") as f:
+            line_count = sum(1 for _ in f)
+            size_ssl_dataset = line_count - 1  # header
+        return size_ssl_dataset
+
+    def load_dataset(self, split: str, **kwargs) -> None:
+        manifest = f"{self.cfg.data}/{split}.tsv"
         dicts = [self.target_dictionary] if self.cfg.fine_tuning else self.dictionaries
         pad_list = [dict.pad() for dict in dicts]
         eos_list = [dict.eos() for dict in dicts]
-        procs = [LabelEncoder(dict) for dict in dicts] # TODO: change that one
-        paths = [f"{self.cfg.labels_dir_supervised}/{split}.{l}" for l in self.cfg.labels] # TODO: change that one to align with the unsupervised labels paths
+        procs = [LabelEncoder(dict) for dict in dicts]
+        paths = [f"{self.cfg.label_dir}/{split}.{l}" for l in self.cfg.labels]
 
         # hubert v1: pad_audio=True, random_crop=False;
-        self.datasets[split] = HubertDataset(
+        self.datasets[split] = HubertMTLDataset(
             manifest,
             sample_rate=self.cfg.sample_rate,
             label_paths=paths,
             label_rates=self.cfg.label_rate,
+            ssl_num_samples=self._get_size_ssl_dataset(split),
             pad_list=pad_list,
             eos_list=eos_list,
             label_processors=procs,
@@ -79,3 +84,137 @@ class HubertMTLPretrainingTask(HubertPretrainingTask):
             random_crop=self.cfg.random_crop,
             single_target=self.cfg.single_target,
         )
+
+    # In order to control the indices of each batch. I just modified the batch sampler in this
+    # method
+    def get_batch_iterator(
+        self,
+        dataset,
+        max_tokens=None,
+        max_sentences=None,
+        max_positions=None,
+        ignore_invalid_inputs=False,
+        required_batch_size_multiple=1,
+        seed=1,
+        num_shards=1,
+        shard_id=0,
+        num_workers=0,
+        epoch=1,
+        data_buffer_size=0,
+        disable_iterator_cache=False,
+        skip_remainder_batch=False,
+        grouped_shuffling=False,
+        update_epoch_batch_itr=False,
+    ):
+        """
+        Get an iterator that yields batches of data from the given dataset.
+
+        Args:
+            dataset (~fairseq.data.FairseqDataset): dataset to batch
+            max_tokens (int, optional): max number of tokens in each batch
+                (default: None).
+            max_sentences (int, optional): max number of sentences in each
+                batch (default: None).
+            max_positions (optional): max sentence length supported by the
+                model (default: None).
+            ignore_invalid_inputs (bool, optional): don't raise Exception for
+                sentences that are too long (default: False).
+            required_batch_size_multiple (int, optional): require batch size to
+                be a multiple of N (default: 1).
+            seed (int, optional): seed for random number generator for
+                reproducibility (default: 1).
+            num_shards (int, optional): shard the data iterator into N
+                shards (default: 1).
+            shard_id (int, optional): which shard of the data iterator to
+                return (default: 0).
+            num_workers (int, optional): how many subprocesses to use for data
+                loading. 0 means the data will be loaded in the main process
+                (default: 0).
+            epoch (int, optional): the epoch to start the iterator from
+                (default: 1).
+            data_buffer_size (int, optional): number of batches to
+                preload (default: 0).
+            disable_iterator_cache (bool, optional): don't cache the
+                EpochBatchIterator (ignores `FairseqTask::can_reuse_epoch_itr`)
+                (default: False).
+            skip_remainder_batch (bool, optional): if set, discard the last
+                batch in each training epoch, as the last batch is often smaller than
+                    local_batch_size * distributed_word_size (default: ``True``).
+            grouped_shuffling (bool, optional): group batches with each groups
+                containing num_shards batches and shuffle groups. Reduces difference
+                between sequence lengths among workers for batches sorted by length.
+            update_epoch_batch_itr (bool optional): if true then donot use the cached
+                batch iterator for the epoch
+
+        Returns:
+            ~fairseq.iterators.EpochBatchIterator: a batched iterator over the
+                given dataset split
+        """
+        can_reuse_epoch_itr = (
+            not disable_iterator_cache
+            and not update_epoch_batch_itr
+            and self.can_reuse_epoch_itr(dataset)
+        )
+        logger.info(f"can_reuse_epoch_itr = {can_reuse_epoch_itr}")
+        if can_reuse_epoch_itr and dataset in self.dataset_to_epoch_iter:
+            logger.debug("reusing EpochBatchIterator for epoch {}".format(epoch))
+            return self.dataset_to_epoch_iter[dataset]
+
+        assert isinstance(dataset, FairseqDataset)
+
+        # initialize the dataset with the correct starting epoch
+        dataset.set_epoch(epoch)
+
+        def make_batches(dataset, epoch):
+            logger.info(f"creating new batches for epoch {epoch}")
+
+            # # get indices ordered by example size
+            # with data_utils.numpy_seed(seed + epoch):
+            #     indices = dataset.ordered_indices()
+
+            # # filter examples that are too large
+            # if max_positions is not None:
+            #     indices = self.filter_indices_by_size(
+            #         indices, dataset, max_positions, ignore_invalid_inputs
+            #     )
+
+            # create mini-batches with given size constraints
+            batches = UnevenBatchSampler(
+                len(self.dataset),
+                num_samples_unlabelled_dataset=self.dataset.ssl_num_samples,
+            )
+            return batches
+
+        reuse_dataloader = getattr(self.cfg, "reuse_dataloader", True)
+        persistent_workers = getattr(self.cfg, "persistent_workers", True)
+        rebuild_batches = getattr(self.cfg, "rebuild_batches", False)
+        logger.info(f"reuse_dataloader = {reuse_dataloader}")
+        logger.info(f"rebuild_batches = {rebuild_batches}")
+
+        if rebuild_batches:
+            logger.info("batches will be rebuilt for each epoch")
+            batch_sampler = make_batches
+        else:
+            batch_sampler = make_batches(dataset, epoch)
+
+        # return a reusable, sharded iterator
+        epoch_iter = iterators.EpochBatchIterator(
+            dataset=dataset,
+            collate_fn=dataset.collater,
+            batch_sampler=batch_sampler,
+            seed=seed,
+            num_shards=num_shards,
+            shard_id=shard_id,
+            num_workers=num_workers,
+            epoch=epoch,
+            buffer_size=data_buffer_size,
+            skip_remainder_batch=skip_remainder_batch,
+            grouped_shuffling=grouped_shuffling,
+            reuse_dataloader=reuse_dataloader,
+            persistent_workers=persistent_workers,
+        )
+
+        if can_reuse_epoch_itr:
+            self.dataset_to_epoch_iter[dataset] = epoch_iter
+
+        return epoch_iter

--- a/fairseq/tasks/hubert_mtl_pretraining.py
+++ b/fairseq/tasks/hubert_mtl_pretraining.py
@@ -182,8 +182,9 @@ class HubertMTLPretrainingTask(HubertPretrainingTask):
 
             # TODO: see if this is what was expected
             batches = UnevenBatchSampler(
-                len(self.dataset),
-                num_samples_unlabelled_dataset=self.dataset.ssl_num_samples,
+                len(dataset),
+                batch_size=64,  # TODO: use max_tokens somehow instead or define the batch size in the config
+                num_samples_unlabelled_dataset=dataset.ssl_num_samples,
             )
             return batches
 


### PR DESCRIPTION
Modify the HuBERT code to adapt it to a multi-task fashion (with one self-supervised task and one supervised task). In order to do this, I created a hubert mtl classes that inherit from the existing HuBERT code and modified what was needed to get the multi-task training to work. Disclaimer: this makes the training run but the input data is not correct, and some things still need to be modified after fixing the pre-processing input data (like the loss function)

This includes modifying:
-  The training configuration to add the supervised task parameters
-  The model to include the supervised projection layer
-  The batch sampler to sample evenly from both the supervised and the self-supervised tasks
-  The dataset so that it includes both the supervised and self-supervised data
-  The forward pass to mask the supervised samples when forwarding the logits and targets
-  The loss function to account for the supervised samples and weight the ssl and sl tasks